### PR TITLE
Changed base image to node:16-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM debian:stable
-MAINTAINER Vasyl Zakharchenko <vaszakharchenko@gmail.com>
+FROM node:16-alpine
+LABEL maintainer="Vasyl Zakharchenko <vaszakharchenko@gmail.com>"
 LABEL author="Vasyl Zakharchenko"
 LABEL email="vaszakharchenko@gmail.com"
 LABEL name="huawei-hilink"
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y nodejs npm
 # Bundle APP files
 RUN npm i huawei-hilink@1.1.7 -g
-# Install app dependencies
 ENV NPM_CONFIG_LOGLEVEL warn
 ENTRYPOINT ["/usr/local/bin/huawei-hilink"]
 CMD []


### PR DESCRIPTION
This project is awesome, and is helping me automate SMS sending from my lab.

However, when `nodejs` and `npm` are installed on top of the Debian base image, it seems to install a lot of (for this project) unneccesary dependencies, including a ton of X11 stuff, which makes the resulting image one big bloat.

I've replaced it with `node:16-alpine` base image, which doesn't require any additional dependencies, and the resulting image size is about 1/8th of the original one. Build time is obviously significantly reduced as well.

```
$ docker image ls | grep hilink
hilink-new              latest          7f9329b62277   8 minutes ago    116MB
hilink-orig             latest          d78023fa6dd1   13 minutes ago   962MB
```

I've also refactored `MAINTAINER` directive, as it seems to have been [deprecated](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated) in Dockerfile.